### PR TITLE
Use cs:~containers/keepalived

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -19,7 +19,7 @@ point of failure.
 # juju deploy canonical-kubernetes
 
 # deploy the keepalived charm
-juju deploy keepalived
+juju deploy cs:~containers/keepalived
 
 # add new keepalived relations
 juju relate keepalived:juju-info kubeapi-load-balancer:juju-info


### PR DESCRIPTION
keepalived charm is not a promulgated one, so deployment instructions
need to use the containers namespace.