### PR TITLE
Add support for series upgrade

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7]
+        python: [3.5, 3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -1,0 +1,22 @@
+name: Run tests with Tox
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.5, 3.6, 3.7]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Tox and any other packages
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e py  # Run tox using the version of Python in `PATH`

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.tox/
+__pycache__/
+*.pyc

--- a/src/layer.yaml
+++ b/src/layer.yaml
@@ -1,4 +1,4 @@
-includes: ['layer:basic', 'interface:juju-info', 'interface:public-address', 'interface:http']
+includes: ['layer:basic', 'interface:juju-info', 'interface:public-address', 'interface:http', 'layer:status']
 repo: https://github.com/juju-solutions/charm-keepalived.git
 options:
   basic:

--- a/src/reactive/keepalived.py
+++ b/src/reactive/keepalived.py
@@ -8,10 +8,11 @@ from charms.reactive.flags import clear_flag
 
 from charmhelpers.core.templating import render
 from charmhelpers.fetch import apt_update, apt_install
-from charmhelpers.core.hookenv import status_set
 from charmhelpers.core.hookenv import config, is_leader
 from charmhelpers.core.host import service_restart
 from charmhelpers.core.host import service_pause, service_resume
+
+from charms.layer import status
 
 
 SYSCTL_FILE = os.path.join(os.sep, 'etc', 'sysctl.d', '50-keepalived.conf')
@@ -22,7 +23,7 @@ KEEPALIVED_CONFIG_FILE = os.path.join(os.sep, 'etc', 'keepalived',
 @when_not('keepalived.package.installed')
 def install_keepalived_package():
     ''' Install keepalived package '''
-    status_set('maintenance', 'Installing keepalived')
+    status.maintenance('Installing keepalived')
 
     apt_update(fatal=True)
     apt_install('keepalived', fatal=True)
@@ -49,7 +50,7 @@ def configure_keepalived_service():
 
     virtual_ip = config().get('virtual_ip')
     if virtual_ip == "":
-        status_set('blocked', 'Please configure virtual ips')
+        status.blocked('Please configure virtual ips')
         return
 
     network_interface = config().get('network_interface')
@@ -75,7 +76,7 @@ def configure_keepalived_service():
            perms=0o644)
     service_restart('procps')
 
-    status_set('active', 'VIP ready')
+    status.active('VIP ready')
     set_flag('keepalived.started')
 
 
@@ -113,7 +114,7 @@ def upgrade_charm():
 def pre_series_upgrade():
     service_pause('keepalived')
     service_pause('procps')
-    status_set('blocked', 'Series upgrade in progress')
+    status.blocked('Series upgrade in progress')
 
 
 @hook('post-series-upgrade')

--- a/src/reactive/keepalived.py
+++ b/src/reactive/keepalived.py
@@ -8,9 +8,10 @@ from charms.reactive.flags import clear_flag
 
 from charmhelpers.core.templating import render
 from charmhelpers.fetch import apt_update, apt_install
-from charmhelpers.core.hookenv import log, status_set
+from charmhelpers.core.hookenv import status_set
 from charmhelpers.core.hookenv import config, is_leader
 from charmhelpers.core.host import service_restart
+from charmhelpers.core.host import service_pause, service_resume
 
 
 SYSCTL_FILE = os.path.join(os.sep, 'etc', 'sysctl.d', '50-keepalived.conf')
@@ -28,6 +29,7 @@ def install_keepalived_package():
 
     set_flag('keepalived.package.installed')
 
+
 def default_route_interface():
     ''' Returns the network interface of the system's default route '''
     default_interface = None
@@ -38,8 +40,10 @@ def default_route_interface():
             default_interface = line.split(' ')[-1]
             return default_interface
 
+
 @when('keepalived.package.installed')
 @when_not('keepalived.started')
+@when_not('upgrade.series.in-progress')
 def configure_keepalived_service():
     ''' Set up the keepalived service '''
 
@@ -58,7 +62,7 @@ def configure_keepalived_service():
                'router_id': config().get('router_id'),
                'service_port': config().get('port'),
                'healthcheck_interval': config().get('healthcheck_interval'),
-              }
+               }
     render(source='keepalived.conf',
            target=KEEPALIVED_CONFIG_FILE,
            context=context,
@@ -102,4 +106,18 @@ def loadbalancer_available(loadbalancer):
 
 @hook('upgrade-charm')
 def upgrade_charm():
+    clear_flag('keepalived.started')
+
+
+@hook('pre-series-upgrade')
+def pre_series_upgrade():
+    service_pause('keepalived')
+    service_pause('procps')
+    status_set('blocked', 'Series upgrade in progress')
+
+
+@hook('post-series-upgrade')
+def post_series_upgrade():
+    service_resume('keepalived')
+    service_resume('procps')
     clear_flag('keepalived.started')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import charms.unit_test
+
+charms.unit_test.patch_reactive()

--- a/tests/test_keepalived.py
+++ b/tests/test_keepalived.py
@@ -1,4 +1,5 @@
-from charmhelpers.core import hookenv, host  # patched
+from charmhelpers.core import host  # patched
+from charms.layer import status  # patched
 
 from reactive import keepalived as handlers
 
@@ -6,12 +7,12 @@ from reactive import keepalived as handlers
 def test_series_upgrade():
     assert host.service_pause.call_count == 0
     assert host.service_resume.call_count == 0
-    assert hookenv.status_set.call_count == 0
+    assert status.blocked.call_count == 0
     handlers.pre_series_upgrade()
     assert host.service_pause.call_count == 2
     assert host.service_resume.call_count == 0
-    assert hookenv.status_set.call_count == 1
+    assert status.blocked.call_count == 1
     handlers.post_series_upgrade()
     assert host.service_pause.call_count == 2
     assert host.service_resume.call_count == 2
-    assert hookenv.status_set.call_count == 1
+    assert status.blocked.call_count == 1

--- a/tests/test_keepalived.py
+++ b/tests/test_keepalived.py
@@ -8,10 +8,10 @@ def test_series_upgrade():
     assert host.service_resume.call_count == 0
     assert hookenv.status_set.call_count == 0
     handlers.pre_series_upgrade()
-    assert host.service_pause.call_count == 1
+    assert host.service_pause.call_count == 2
     assert host.service_resume.call_count == 0
     assert hookenv.status_set.call_count == 1
     handlers.post_series_upgrade()
-    assert host.service_pause.call_count == 1
-    assert host.service_resume.call_count == 1
+    assert host.service_pause.call_count == 2
+    assert host.service_resume.call_count == 2
     assert hookenv.status_set.call_count == 1

--- a/tests/test_keepalived.py
+++ b/tests/test_keepalived.py
@@ -1,0 +1,17 @@
+from charmhelpers.core import hookenv, host  # patched
+
+from reactive import keepalived as handlers
+
+
+def test_series_upgrade():
+    assert host.service_pause.call_count == 0
+    assert host.service_resume.call_count == 0
+    assert hookenv.status_set.call_count == 0
+    handlers.pre_series_upgrade()
+    assert host.service_pause.call_count == 1
+    assert host.service_resume.call_count == 0
+    assert hookenv.status_set.call_count == 1
+    handlers.post_series_upgrade()
+    assert host.service_pause.call_count == 1
+    assert host.service_resume.call_count == 1
+    assert hookenv.status_set.call_count == 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint
+envlist = lint,py3
 skipsdist = True
 
 [testenv]
@@ -14,6 +14,7 @@ install_command =
   pip install {opts} {packages}
 deps =
     -r{toxinidir}/requirements.txt
+    git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
 
 [testenv:build]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -3,18 +3,24 @@ envlist = lint,py3
 skipsdist = True
 
 [testenv]
-setenv = VIRTUAL_ENV={envdir}
-         PYTHONHASHSEED=0
-         TERM=linux
-         LAYER_PATH={toxinidir}/layers
-         INTERFACE_PATH={toxinidir}/interfaces
-         JUJU_REPOSITORY={toxinidir}/build
+basepython = python3
+setenv =
+    VIRTUAL_ENV={envdir}
+    PYTHONHASHSEED=0
+    TERM=linux
+    LAYER_PATH={toxinidir}/layers
+    INTERFACE_PATH={toxinidir}/interfaces
+    JUJU_REPOSITORY={toxinidir}/build
+    PYTHONPATH={toxinidir}/src:{toxinidir}/src/lib
 passenv = http_proxy https_proxy
 install_command =
   pip install {opts} {packages}
 deps =
     -r{toxinidir}/requirements.txt
+    pytest
+    ipdb
     git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
+commands = pytest --tb native -s {posargs}
 
 [testenv:build]
 basepython = python2.7


### PR DESCRIPTION
Pause the services and set a blocked status during series upgrade.

Note that this means that the principal service will be removed from routing prior to its `pre-series-upgrade` hook from firing (since the `pre-series-upgrade` hook on subordinates fire first). That seems like the most reasonable thing to do, but I'm a little uncertain if there may be services for which this would be a problem.

Part of https://bugs.launchpad.net/charm-keepalived/+bug/1869944