### PR TITLE
fix path to bash 'script'

### DIFF
--- a/src/templates/keepalived.conf
+++ b/src/templates/keepalived.conf
@@ -1,6 +1,6 @@
 vrrp_script chk_svc_port {
     # returns 1 if connection is refused
-    script "bash -c '</dev/tcp/127.0.0.1/{{ service_port }}'"
+    script "/bin/bash -c '</dev/tcp/127.0.0.1/{{ service_port }}'"
     # check every 2 seconds
     interval {{ healthcheck_interval }}
     # make sure master priority drops below backup priority on failure


### PR DESCRIPTION
in order to run svc_check the path to bash must be provided
otherwise we see next error message in service log:

May 03 08:31:41 srv3 Keepalived_vrrp[614395]: Script bash cannot be accessed - No such file or directory
May 03 08:31:41 srv3 Keepalived_vrrp[614395]: Disabling track script chk_svc_port since not found/accessible

with provided path it's run successfully even with WARNING message about user:
May 03 12:50:48 srv3 Keepalived_vrrp[1861909]: WARNING - default user 'keepalived_script' for script execution does not exist - please create.