### PR TITLE
install net-tools to be able to run 'route' 

### DIFF
--- a/src/reactive/keepalived.py
+++ b/src/reactive/keepalived.py
@@ -26,7 +26,7 @@ def install_keepalived_package():
     status.maintenance('Installing keepalived')
 
     apt_update(fatal=True)
-    apt_install('keepalived', fatal=True)
+    apt_install(['keepalived', 'net-tools'], fatal=True)
 
     set_flag('keepalived.package.installed')
 

--- a/src/templates/keepalived.conf
+++ b/src/templates/keepalived.conf
@@ -1,6 +1,6 @@
 vrrp_script chk_svc_port {
     # returns 1 if connection is refused
-    script "bash -c '</dev/tcp/127.0.0.1/{{ service_port }}'"
+    script "/bin/bash -c '</dev/tcp/127.0.0.1/{{ service_port }}'"
     # check every 2 seconds
     interval {{ healthcheck_interval }}
     # make sure master priority drops below backup priority on failure


### PR DESCRIPTION
in pure Ubuntu 20.04 this package is absent and charm fails to start.